### PR TITLE
Selection of a database to retrieve data is posible

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,16 @@ What it won't do:
 
 Usage
 -----
-
+<pre>
+import biomart
+web = "http://www.biomart.org/biomart"
+name = 'hsapiens_gene_ensembl'
+server = biomart.BiomartServer(web)
+server.set_verbose(True)
+server.show_databases()
+ensembl_ds = biomart.BiomartDataset(web, name=name)
+ensembl_ds.fetch_configuration()
+</pre>
 Import Biomart module
 <pre>
 from biomart import BiomartServer

--- a/README.md
+++ b/README.md
@@ -43,45 +43,47 @@ server.http_proxy = os.environ.get('http_proxy', 'http://my_http_proxy.org')
 
 Interact with the biomart server
 <pre>
+from biomart import BiomartServer
+
+server = BiomartServer("http://www.biomart.org/biomart")
 # show server databases
-print server.show_databases()
+#server.show_databases()
 
 # show server datasets
-print server.show_datasets()
+#server.show_datasets()
 
 # use the 'uniprot' dataset
 uniprot = server.datasets['uniprot']
-
+# show all available filters and attributes of the 'uniprot' dataset
+uniprot.show_filters()
+uniprot.show_attributes()
 # run a search with the default filters and attributes - equivalent to hitting "Results" on the web interface.
 # this will return a lot of data.
 response = uniprot.search()
-response = uniprot.search( header = 1 ) # if you need the columns header
-
+response = uniprot.search(header=1) # if you need the columns header
 # response format is TSV
-for line in response.iter_lines():
-  print line.split("\t")
 
+params = {}
 # run a count with the default filters and attributes - equivalent to hitting "Count" on the web interface
-response = uniprot.count()
-print response.text
+response = uniprot.count(params) #TODO: Fix this ;)
+print response.text.rstrip()
 
-# show all available filters and attributes of the 'uniprot' dataset
-print uniprot.show_filters()
-print uniprot.show_attributes()
 
 # run a search with custom filters and default attributes.
 response = uniprot.search({
   'filters': {
       'accession': 'Q9FMA1'
   }
-}, header = 1 )
-
+}, header=1)
+for line in response.iter_lines():
+    print line
 response = uniprot.search({
   'filters': {
       'accession': ['Q9FMA1', 'Q8LFJ9']  # ID-list specified accessions
   }
-}, header = 1 )
-
+}, header=1)
+for line in response.iter_lines():
+    print line
 # run a search with custom filters and attributes
 response = uniprot.search({
   'filters': {
@@ -91,16 +93,6 @@ response = uniprot.search({
       'accession', 'protein_name'
   ]
 })
-</pre>
-
-Shortcut function: connect directly to a biomart dataset
-<pre>
-from biomart import BiomartDataset
-
-interpro = BiomartDataset( "http://www.biomart.org/biomart", name = 'entry' )
-
-response = interpro.search({
-  'filters': { 'entry_id': 'IPR027603' },
-  'attributes': [ 'entry_name', 'abstract' ]
-})
+for line in response.iter_lines():
+    print line
 </pre>

--- a/biomart/__init__.py
+++ b/biomart/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from attribute import BiomartAttribute
 from database import BiomartDatabase
 from dataset import BiomartDataset

--- a/biomart/__init__.py
+++ b/biomart/__init__.py
@@ -1,8 +1,10 @@
-from server import BiomartServer
+from attribute import BiomartAttribute
 from database import BiomartDatabase
 from dataset import BiomartDataset
 from filter import BiomartFilter
-from attribute import BiomartAttribute
+from server import BiomartServer
+
 
 class BiomartException(Exception):
+    """Parent exception of Biomart package"""
     pass

--- a/biomart/attribute.py
+++ b/biomart/attribute.py
@@ -1,22 +1,16 @@
 class BiomartAttribute(object):
-    """Object that stores the parameters in name, displayName, default
-     and hidden."""
+    """Object that stores the attributes parameters of a dataset"""
 
     def __init__(self, params):
-        """Creates a new instance of the BiomartAttribute with the selected
-        parameters"""
-        self.name = params['internalName']
-        self.displayName = (
-            'displayName' in params and params['displayName'] == 'true')
-        self.default = ('default' in params and params['default'] == 'true')
-        self.hidden = ('hidden' in params and params['hidden'] == 'true')
-        print self.name
-        print self.displayName
-        print self.default
-        print self.hidden
+        """Creates a new instance of the BiomartAttribute."""
+
+        for name, value in params.iteritems():
+            if name == "internalName":
+                self.name = params['internalName']
+                continue
+            else:
+                setattr(self, name, value)
 
     def __repr__(self):
-        """Set the reproducible name of the object"""
-        if self.default:
-            return "%s (default)" % self.displayName
+        """Set the reproducibility name of the object"""
         return self.name

--- a/biomart/attribute.py
+++ b/biomart/attribute.py
@@ -1,12 +1,22 @@
 class BiomartAttribute(object):
+    """Object that stores the parameters in name, displayName, default
+     and hidden."""
+
     def __init__(self, params):
+        """Creates a new instance of the BiomartAttribute with the selected
+        parameters"""
         self.name = params['internalName']
-        self.displayName = ('displayName' in params and params['displayName'] == 'true')
+        self.displayName = (
+            'displayName' in params and params['displayName'] == 'true')
         self.default = ('default' in params and params['default'] == 'true')
         self.hidden = ('hidden' in params and params['hidden'] == 'true')
-    
+        print self.name
+        print self.displayName
+        print self.default
+        print self.hidden
+
     def __repr__(self):
+        """Set the reproducible name of the object"""
         if self.default:
             return "%s (default)" % self.displayName
         return self.name
-    

--- a/biomart/database.py
+++ b/biomart/database.py
@@ -1,52 +1,66 @@
-import pprint
 import biomart
+import pprint
 
-class BiomartDatabase(biomart.BiomartServer):
+import server
+
+
+class BiomartDatabase(server.BiomartServer):
+    """Object that inherits from BiomartServer that handles databases"""
+
     def __init__(self, url, *args, **kwargs):
+        """Creates a new instance of BiomartDatabase using arguments from 
+        BiomartServer object"""
         super(BiomartDatabase, self).__init__(url, *args, **kwargs)
-        
-        if not 'name' in kwargs:
-            raise biomart.BiomartException("[BiomartDatabase] expecting (not empty) 'name' argument")
 
-        self.add_property( 'name', kwargs['name'] )
-        self.add_property( 'displayName', kwargs.get('displayName', None) )
-        self.add_property( 'visible', (int(kwargs.get('visible', 0))) == 1 )
+        if not 'name' in kwargs:
+            raise biomart.BiomartException(
+                "[BiomartDatabase] expecting (not empty) 'name' argument")
+
+        self.add_property('name', kwargs['name'])
+        self.add_property('displayName', kwargs.get('displayName', None))
+        self.add_property('visible', (int(kwargs.get('visible', 0))) == 1)
 
         self._datasets = {}
-    
+
     def __repr__(self):
+        """Turns the displayName to the name of the object or the name"""
         if self.displayName:
             return unicode(self.displayName)
-        return unicode( self.name )
-    
+        return unicode(self.name)
+
     @property
     def datasets(self):
+        """Return the datasets available"""
         if not self._datasets:
             self.fetch_datasets()
         return self._datasets
-    
+
     def show_datasets(self):
-        pprint.pprint( self.datasets )
+        """Pretty print of known datasets"""
+        pprint.pprint(self.datasets)
 
     def fetch_datasets(self):
-        if self.verbose: print "[BiomartDatabase:'%s'] Fetching datasets" % self.name
-        
+        """Fetch a dataset"""
+        if self.verbose:
+            print "[BiomartDatabase:'%s'] Fetching datasets" % self.name
+
         if not hasattr(self, '_datasets'):
             self._datasets = {}
-        
-        r = self.GET( type = 'datasets', mart = self.name )
+
+        r = self.GET(type='datasets', mart=self.name)
 
         for line in r.iter_lines():
+            print line
             line = line.rstrip("\n").split("\t")
             if len(line) > 3:
                 name = line[1]
                 self._datasets[name] = biomart.BiomartDataset(
-                    url         = self.url,
-                    http_proxy  = self.http_proxy,
-                    https_proxy = self.https_proxy,
-                    name        = name,
-                    displayName = line[2],
-                    visible     = int(line[3]),
-                    verbose     = self.verbose,
-                    is_alive    = self.is_alive
+                    url=self.url,
+                    http_proxy=self.http_proxy,
+                    https_proxy=self.https_proxy,
+                    name=name,
+                    displayName=line[2],
+                    visible=int(line[3]),
+                    verbose=self.verbose,
+                    is_alive=self.is_alive
                 )

--- a/biomart/database.py
+++ b/biomart/database.py
@@ -19,7 +19,6 @@ class BiomartDatabase(server.BiomartServer):
         self.add_property('name', kwargs['name'])
         self.add_property('displayName', kwargs.get('displayName', None))
         self.add_property('visible', (int(kwargs.get('visible', 0))) == 1)
-
         self._datasets = {}
 
     def __repr__(self):
@@ -61,5 +60,6 @@ class BiomartDatabase(server.BiomartServer):
                     displayName=line[2],
                     visible=int(line[3]),
                     verbose=self.verbose,
-                    is_alive=self.is_alive
+                    is_alive=self.is_alive,
+                    database=self.name
                 )

--- a/biomart/database.py
+++ b/biomart/database.py
@@ -47,10 +47,9 @@ class BiomartDatabase(server.BiomartServer):
         if not hasattr(self, '_datasets'):
             self._datasets = {}
 
-        r = self.GET(type='datasets', mart=self.name)
+        r = self.get(type='datasets', mart=self.name)
 
         for line in r.iter_lines():
-            print line
             line = line.rstrip("\n").split("\t")
             if len(line) > 3:
                 name = line[1]

--- a/biomart/database.py
+++ b/biomart/database.py
@@ -19,6 +19,8 @@ class BiomartDatabase(server.BiomartServer):
         self.add_property('name', kwargs['name'])
         self.add_property('displayName', kwargs.get('displayName', None))
         self.add_property('visible', (int(kwargs.get('visible', 0))) == 1)
+        self.assert_alive = None
+        self.ndatasets = 0
         self._datasets = {}
 
     def __repr__(self):
@@ -41,7 +43,7 @@ class BiomartDatabase(server.BiomartServer):
     def fetch_datasets(self):
         """Fetch a dataset"""
         if self.verbose:
-            print "[BiomartDatabase:'%s'] Fetching datasets" % self.name
+            print "[BiomartDatabase:'%s'] Fetching database" % self.name
 
         if not hasattr(self, '_datasets'):
             self._datasets = {}
@@ -63,3 +65,5 @@ class BiomartDatabase(server.BiomartServer):
                     is_alive=self.is_alive,
                     database=self.name
                 )
+                # Adds the number of datasets of each database
+                self.ndatasets += 1

--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -7,7 +7,8 @@ class BiomartDataset(biomart.BiomartServer):
         super( BiomartDataset, self ).__init__( url, *args, **kwargs )
 
         if not 'name' in kwargs:
-            raise biomart.BiomartException("[BiomartDataset] expecting (not empty) 'name' argument")
+            msg = "[BiomartDataset] expecting (not empty) 'name' argument"
+            raise biomart.BiomartException(msg)
 
         self.add_property( 'name', kwargs['name'] )
         self.add_property( 'displayName', kwargs.get('displayName', None) )
@@ -44,7 +45,8 @@ class BiomartDataset(biomart.BiomartServer):
         pprint.pprint(self._attributes.keys())
     
     def fetch_configuration(self):
-        if self.verbose: print "[BiomartDataset:'%s'] Fetching filters and attributes" % self.name
+        if self.verbose: 
+            print "[BiomartDataset:'%s'] Fetching filters and attributes" % self.name
 
         r = self.GET(type='configuration',dataset=self.name)
         xml = fromstring( r.text )

--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -21,7 +21,7 @@ class BiomartDataset(database.BiomartDatabase):  # server.BiomartServer
         self.add_property('name', kwargs['name'])
         self.add_property('displayName', kwargs.get('displayName', None))
         self.add_property('visible', (int(kwargs.get('visible', 0))) == 1)
-
+        self.database = kwargs["database"]
         self._filters = []
         self._attributes = []
 

--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -140,4 +140,4 @@ class BiomartDataset(biomart.BiomartServer):
                 attribute_elem = SubElement( dataset, "Attribute" )
                 attribute_elem.set( 'name', str(attribute_name) )
         
-        return self.GET(query=tostring( root ))
+        return self.GET(query=tostring( root )).rstrip()

--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -83,6 +83,7 @@ class BiomartDataset(biomart.BiomartServer):
         dataset.set( 'name', self.name )
         dataset.set( 'interface', 'default' )
         
+
         filters    = params.get( 'filters', {} )
         attributes = params.get( 'attributes', [] )
         
@@ -91,7 +92,7 @@ class BiomartDataset(biomart.BiomartServer):
             try:
                 filters.items()
             except AttributeError:
-                msg = "The parameters should be a dictionary"
+                msg = "The filters value should be a dictionary"
                 raise biomart.BiomartException(msg)
             for name, value in filters.items():
                 try:
@@ -126,7 +127,7 @@ class BiomartDataset(biomart.BiomartServer):
         
         # Add attributes to XML, unless "count"
         if not count:
-            if attributes:
+            if attributes and isinstance(attributes, list):
                 for attribute_name in attributes:
                     if not attribute_name in self.attributes.keys():
                         raise biomart.BiomartException( "The Attribute '%s' does not exist" % attribute_name )

--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -2,10 +2,11 @@ import biomart
 import pprint
 from xml.etree.ElementTree import Element, SubElement, tostring, fromstring
 
+import database
 import server
 
 
-class BiomartDataset(server.BiomartServer):
+class BiomartDataset(database.BiomartDatabase):  # server.BiomartServer
     """Object to handle dataset of a Biomart Server"""
 
     def __init__(self, url, *args, **kwargs):
@@ -21,8 +22,8 @@ class BiomartDataset(server.BiomartServer):
         self.add_property('displayName', kwargs.get('displayName', None))
         self.add_property('visible', (int(kwargs.get('visible', 0))) == 1)
 
-        self._filters = {}
-        self._attributes = {}
+        self._filters = []
+        self._attributes = []
 
     def __repr__(self):
         """Set the value to reproduce when printing the object"""
@@ -48,33 +49,33 @@ class BiomartDataset(server.BiomartServer):
         """Prints pretty the filters it has"""
         if not self._filters:
             self.fetch_configuration()
-        pprint.pprint(self._filters.keys())
+        pprint.pprint(self._filters)
 
     def show_attributes(self):
         """Prints pretty the attributes it has"""
         if not self._attributes:
             self.fetch_configuration()
-        pprint.pprint(self._attributes.keys())
+        pprint.pprint(self._attributes)
 
     def fetch_configuration(self):
         """Fetch the configuration of the dataset of its name"""
         if self.verbose:
             print "[BiomartDataset:'%s'] Fetching filters and attributes" % self.name
 
-        r = self.GET(type='configuration', dataset=self.name)
+        r = self.get(type='configuration', dataset=self.name)
         xml = fromstring(r.text)
 
         # Fetch filters options
         for filter_description in xml.iter('FilterDescription'):
-            name = filter_description.attrib['internalName']
-            self._filters[name] = biomart.BiomartFilter(
-                filter_description.attrib)
+            #             name = filter_description.attrib['internalName']
+            self._filters.append(biomart.BiomartFilter(
+                filter_description.attrib))
 
         # Fetch attributes options
         for attribute_description in xml.iter('AttributeDescription'):
-            name = attribute_description.attrib['internalName']
-            self._attributes[name] = biomart.BiomartAttribute(
-                attribute_description.attrib)
+            #             name = attribute_description.attrib['internalName']
+            self._attributes.append(biomart.BiomartAttribute(
+                attribute_description.attrib))
         if self.verbose:
             print "[BiomartDataset:'%s'] Configuration fetch correctly" % self.name
 
@@ -169,4 +170,4 @@ class BiomartDataset(server.BiomartServer):
                 attribute_elem = SubElement(dataset, "Attribute")
                 attribute_elem.set('name', str(attribute_name))
 
-        return self.GET(query=tostring(root)).rstrip()
+        return self.get(query=tostring(root)).rstrip()

--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -88,6 +88,11 @@ class BiomartDataset(biomart.BiomartServer):
         
         # Add filters to XML
         if filters:
+            try:
+                filters.items()
+            except AttributeError:
+                msg = "The parameters should be a dictionary"
+                raise biomart.BiomartException(msg)
             for name, value in filters.items():
                 try:
                     filter = self.filters[name]

--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -1,78 +1,97 @@
-from xml.etree.ElementTree import Element, SubElement, tostring, fromstring
-import pprint
 import biomart
+import pprint
+from xml.etree.ElementTree import Element, SubElement, tostring, fromstring
 
-class BiomartDataset(biomart.BiomartServer):
+import server
+
+
+class BiomartDataset(server.BiomartServer):
+    """Object to handle dataset of a Biomart Server"""
+
     def __init__(self, url, *args, **kwargs):
-        super( BiomartDataset, self ).__init__( url, *args, **kwargs )
+        """Creates a new instance of the BiomartDataset inhering all the 
+        arguments from the BiomartServer object."""
+        super(BiomartDataset, self).__init__(url, *args, **kwargs)
 
         if not 'name' in kwargs:
             msg = "[BiomartDataset] expecting (not empty) 'name' argument"
             raise biomart.BiomartException(msg)
 
-        self.add_property( 'name', kwargs['name'] )
-        self.add_property( 'displayName', kwargs.get('displayName', None) )
-        self.add_property( 'visible', (int(kwargs.get('visible', 0))) == 1 )
-        
+        self.add_property('name', kwargs['name'])
+        self.add_property('displayName', kwargs.get('displayName', None))
+        self.add_property('visible', (int(kwargs.get('visible', 0))) == 1)
+
         self._filters = {}
         self._attributes = {}
 
     def __repr__(self):
+        """Set the value to reproduce when printing the object"""
         if self.displayName:
             return unicode(self.displayName)
-        return unicode( self.name )
-    
+        return unicode(self.name)
+
     @property
     def attributes(self):
+        """Fetch the attributes"""
         if not self._attributes:
             self.fetch_configuration()
         return self._attributes
-    
+
     @property
     def filters(self):
+        """Fetch the filters"""
         if not self._filters:
             self.fetch_configuration()
         return self._filters
-    
+
     def show_filters(self):
+        """Prints pretty the filters it has"""
         if not self._filters:
             self.fetch_configuration()
         pprint.pprint(self._filters.keys())
-    
+
     def show_attributes(self):
+        """Prints pretty the attributes it has"""
         if not self._attributes:
             self.fetch_configuration()
         pprint.pprint(self._attributes.keys())
-    
+
     def fetch_configuration(self):
-        if self.verbose: 
+        """Fetch the configuration of the dataset of its name"""
+        if self.verbose:
             print "[BiomartDataset:'%s'] Fetching filters and attributes" % self.name
 
-        r = self.GET(type='configuration',dataset=self.name)
-        xml = fromstring( r.text )
-        
-        # Filters
-        for filter_description in xml.iter( 'FilterDescription' ):
+        r = self.GET(type='configuration', dataset=self.name)
+        xml = fromstring(r.text)
+
+        # Fetch filters options
+        for filter_description in xml.iter('FilterDescription'):
             name = filter_description.attrib['internalName']
-            self._filters[name] = biomart.BiomartFilter( filter_description.attrib )
-        
-        # Attributes
-        for attribute_description in xml.iter( 'AttributeDescription' ):
+            self._filters[name] = biomart.BiomartFilter(
+                filter_description.attrib)
+
+        # Fetch attributes options
+        for attribute_description in xml.iter('AttributeDescription'):
             name = attribute_description.attrib['internalName']
-            self._attributes[name] = biomart.BiomartAttribute( attribute_description.attrib )
-    
-    def count( self, params ):
-        return self.search( params, count = True )
-    
-    def search( self, params = {}, header = 0, count = False ):
+            self._attributes[name] = biomart.BiomartAttribute(
+                attribute_description.attrib)
+        if self.verbose:
+            print "[BiomartDataset:'%s'] Configuration fetch correctly" % self.name
+
+    def count(self, params={}):
+        """Search but counting the number of results."""
+        return self.search(params, count=True)
+
+    def search(self, params={}, header=0, count=False):
+        """Search using the parameters, and the options"""
         if not self._filters or not self._attributes:
             self.fetch_configuration()
 
         if self.verbose:
             print "[BiomartDataset:'%s'] Searching using following params:" % self.name
             pprint.pprint(params)
-        
-        root = Element( 'Query' )
+
+        root = Element('Query')
         root.set('virtualSchemaName', 'default')
         root.set('formatter', 'TSV')
         root.set('header', str(header))
@@ -80,15 +99,14 @@ class BiomartDataset(biomart.BiomartServer):
         root.set('datasetConfigVersion', '0.6')
         if count:
             root.set('count', '1')
-        
-        dataset = SubElement( root, "Dataset" )
-        dataset.set( 'name', self.name )
-        dataset.set( 'interface', 'default' )
-        
 
-        filters    = params.get( 'filters', {} )
-        attributes = params.get( 'attributes', [] )
-        
+        dataset = SubElement(root, "Dataset")
+        dataset.set('name', self.name)
+        dataset.set('interface', 'default')
+
+        filters = params.get('filters', {})
+        attributes = params.get('attributes', [])
+
         # Add filters to XML
         if filters:
             try:
@@ -96,51 +114,59 @@ class BiomartDataset(biomart.BiomartServer):
             except AttributeError:
                 msg = "The filters value should be a dictionary"
                 raise biomart.BiomartException(msg)
+
             for name, value in filters.items():
                 try:
                     filter_ = self.filters[name]
                 except KeyError:
-                    raise biomart.BiomartException( "The filter '%s' does not exist. Use one of: " % (name, ', '.join(self.attributes.keys())) )
-                
-                filter_elem = SubElement( dataset, "Filter" )
-                filter_elem.set( 'name', name )
-                
+                    msg = "The filter '%s' does not exist. Use one of: " % (
+                        name, ', '.join(self.attributes.keys()))
+                    raise biomart.BiomartException()
+
+                filter_elem = SubElement(dataset, "Filter")
+                filter_elem.set('name', name)
+
                 if filter_.type == 'boolean':
-                    if value == True or value.lower() == 'included' or value.lower() == 'only':
-                        filter_elem.set( 'excluded', '0' )
+                    if value == True or value.lower() in ['included', 'only']:
+                        filter_elem.set('excluded', '0')
                     elif value == False or value.lower() == 'excluded':
-                        filter_elem.set( 'excluded', '1' )
+                        filter_elem.set('excluded', '1')
                     else:
-                        raise biomart.BiomartException( "The boolean filter '%s' can only accept True, 'included', 'only', False, 'excluded'" % self.name )
-                
+                        msg = "The boolean filter '%s' can only accept True, " \
+                            "'included', 'only', False, 'excluded'" % self.name
+                        raise biomart.BiomartException(msg)
+
                 else:
-                    if isinstance( value, list ) or isinstance( value, tuple ):
-                        value = ",".join( value )
-                    filter_elem.set( 'value', value )
+                    if isinstance(value, list) or isinstance(value, tuple):
+                        value = ",".join(value)
+                    filter_elem.set('value', value)
         else:
             for filter_ in self.filters.values():
                 if filter.default and filter.default_value:
-                    filter_elem = SubElement( dataset )
-                    filter_elem.set( 'name', str(filter.name) )
+                    filter_elem = SubElement(dataset)
+                    filter_elem.set('name', str(filter.name))
                     if filter.type == 'boolean':
-                        filter_elem.set( 'excluded', str(filter.default_value) )
+                        filter_elem.set('excluded', str(filter.default_value))
                     else:
-                        filter_elem.set( 'value', str(filter.default_value) )
-        
+                        filter_elem.set('value', str(filter.default_value))
+
         # Add attributes to XML, unless "count"
         if not count:
             if attributes and isinstance(attributes, list):
                 for attribute_name in attributes:
                     if not attribute_name in self.attributes.keys():
-                        raise biomart.BiomartException( "The Attribute '%s' does not exist" % attribute_name )
+                        raise biomart.BiomartException(
+                            "The Attribute '%s' does not exist" % attribute_name)
             else:
-                attributes = [ attr.name for attr in self.attributes.values() if attr.default ]
-            
+                attributes = [
+                    attr.name for attr in self.attributes.values() if attr.default]
+
             if not attributes:
-                raise biomart.BiomartException('No attributes selected, please select at least one')
-            
+                raise biomart.BiomartException(
+                    'No attributes selected, please select at least one')
+
             for attribute_name in attributes:
-                attribute_elem = SubElement( dataset, "Attribute" )
-                attribute_elem.set( 'name', str(attribute_name) )
-        
-        return self.GET(query=tostring( root )).rstrip()
+                attribute_elem = SubElement(dataset, "Attribute")
+                attribute_elem.set('name', str(attribute_name))
+
+        return self.GET(query=tostring(root)).rstrip()

--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -1,4 +1,4 @@
-from xml.etree.ElementTree import ElementTree, Element, SubElement, tostring, fromstring
+from xml.etree.ElementTree import Element, SubElement, tostring, fromstring
 import pprint
 import biomart
 
@@ -96,14 +96,14 @@ class BiomartDataset(biomart.BiomartServer):
                 raise biomart.BiomartException(msg)
             for name, value in filters.items():
                 try:
-                    filter = self.filters[name]
+                    filter_ = self.filters[name]
                 except KeyError:
                     raise biomart.BiomartException( "The filter '%s' does not exist. Use one of: " % (name, ', '.join(self.attributes.keys())) )
                 
                 filter_elem = SubElement( dataset, "Filter" )
                 filter_elem.set( 'name', name )
                 
-                if filter.type == 'boolean':
+                if filter_.type == 'boolean':
                     if value == True or value.lower() == 'included' or value.lower() == 'only':
                         filter_elem.set( 'excluded', '0' )
                     elif value == False or value.lower() == 'excluded':
@@ -116,7 +116,7 @@ class BiomartDataset(biomart.BiomartServer):
                         value = ",".join( value )
                     filter_elem.set( 'value', value )
         else:
-            for filter in self.filters.values():
+            for filter_ in self.filters.values():
                 if filter.default and filter.default_value:
                     filter_elem = SubElement( dataset )
                     filter_elem.set( 'name', str(filter.name) )

--- a/biomart/filter.py
+++ b/biomart/filter.py
@@ -1,17 +1,15 @@
 class BiomartFilter(object):
-    """Class that filter a dataset given paramaters"""
+    """Store the filter parameters of a dataset"""
 
     def __init__(self, params):
-        """Given params create a dictionary with them using some default values"""
-        self.name = params['internalName']
-        self.displayName = (
-            'displayName' in params and params['displayName'] == 'true')
-        self.type = ('type' in params and params['type'] == 'true')
-        self.default = ('default' in params and params['default'] == 'true')
-        self.default_value = (
-            'defaultValue' in params and params['defaultValue'] or None)
-        self.hidden = ('hidden' in params and params['hidden'] == 'true')
+        """Given the attributes of a request store them as attributes of these class"""
+        for name, value in params.iteritems():
+            if name == "internalName":
+                self.name = params['internalName']
+                continue
+            else:
+                setattr(self, name, value)
 
     def __repr__(self):
-        """Returns the name of the filter"""
+        """Set the reproducibility name of the object"""
         return self.name

--- a/biomart/filter.py
+++ b/biomart/filter.py
@@ -1,12 +1,16 @@
 class BiomartFilter(object):
+    """Class that filter a dataset given paramaters"""
+
     def __init__(self, params):
+        """Given params create a dictionary with them using some default values"""
         self.name = params['internalName']
-        self.displayName = ('displayName' in params and params['displayName'] == 'true')
+        self.displayName = (
+            'displayName' in params and params['displayName'] == 'true')
         self.type = ('type' in params and params['type'] == 'true')
         self.default = ('default' in params and params['default'] == 'true')
-        self.default_value = 'defaultValue' in params and params['defaultValue'] or None
+        self.default_value = (
+            'defaultValue' in params and params['defaultValue'] or None)
         self.hidden = ('hidden' in params and params['hidden'] == 'true')
-    
+
     def __repr__(self):
         return self.name
-    

--- a/biomart/filter.py
+++ b/biomart/filter.py
@@ -13,4 +13,5 @@ class BiomartFilter(object):
         self.hidden = ('hidden' in params and params['hidden'] == 'true')
 
     def __repr__(self):
+        """Returns the name of the filter"""
         return self.name

--- a/biomart/lib.py
+++ b/biomart/lib.py
@@ -1,0 +1,21 @@
+PUBLIC_BIOMART_URL = "http://www.biomart.org/biomart"
+VERSION = "0.6.0"
+
+
+class Properties(object):
+
+    def add_property(self, name, value):
+        # create local fget and fset functions
+        fget = lambda self: self._get_property(name)
+        fset = lambda self, value: self._set_property(name, value)
+
+        # add property to self
+        setattr(self.__class__, name, property(fget, fset))
+        # add corresponding local variable
+        setattr(self, '_' + name, value)
+
+    def _set_property(self, name, value):
+        setattr(self, '_' + name, value)
+
+    def _get_property(self, name):
+        return getattr(self, '_' + name)

--- a/biomart/lib.py
+++ b/biomart/lib.py
@@ -3,8 +3,14 @@ VERSION = "0.6.0"
 
 
 class Properties(object):
+    """Object to store properties"""
+
+    def __init__(self):
+        """Create a new object of class Properties"""
+        print "Creating Property"
 
     def add_property(self, name, value):
+        """Method to add a property as an attribute of the class"""
         # create local fget and fset functions
         fget = lambda self: self._get_property(name)
         fset = lambda self, value: self._set_property(name, value)
@@ -15,7 +21,9 @@ class Properties(object):
         setattr(self, '_' + name, value)
 
     def _set_property(self, name, value):
+        """Auxiliar function to set the attribute name of the property"""
         setattr(self, '_' + name, value)
 
     def _get_property(self, name):
+        """Retrieve the attribute of the desired name"""
         return getattr(self, '_' + name)

--- a/biomart/server.py
+++ b/biomart/server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import biomart
 import os
 import pprint
@@ -146,7 +145,6 @@ class BiomartServer(Properties):
         if not hasattr(self, '_datasets'):
             self._datasets = {}
         for database_ in self.databases.values():
-            # TODO: Include from which database_ is comming each dataset
             # If a database is provided fetch only datasets from these datset
             if database != None:
                 if database_.name == database or database_.displayName == database:

--- a/biomart/server.py
+++ b/biomart/server.py
@@ -63,12 +63,12 @@ class BiomartServer(Properties):
             print "[BiomartServer:'%s'] is already alive." % self.url
 
     @property
-    def databases(self):
+    def databases(self, database=None):
         """Return a dictionary with the available databases and a description
          of them."""
         if not hasattr(self, '_databases'):
             self._databases = {}
-            self.fetch_databases()
+            self.fetch_databases(database)
         return self._databases
 
     @property
@@ -145,7 +145,7 @@ class BiomartServer(Properties):
         if not hasattr(self, '_datasets'):
             self._datasets = {}
         for database_ in self.databases.values():
-            # If a database is provided fetch only datasets from these datset
+            # If a database is provided fetch only datasets from these dataset
             if database != None:
                 if database_.name == database or database_.displayName == database:
                     self._datasets.update(database_.datasets)

--- a/biomart/server.py
+++ b/biomart/server.py
@@ -1,15 +1,19 @@
+# -*- coding: utf-8 -*-
+import biomart
 import os
 import pprint
 import requests
 from xml.etree.ElementTree import fromstring
 
-import biomart
 from lib import Properties, PUBLIC_BIOMART_URL
 
 
 class BiomartServer(Properties):
+    """Object to handle connection to Biomart servers"""
 
     def __init__(self, url=PUBLIC_BIOMART_URL, *args, **kwargs):
+        """Creates a new instance connecting to the biomart website.
+        By default use the biomart url"""
         if not 'martservice' in url:
             url += '/martservice'
         if not 'http://' in url:
@@ -21,18 +25,20 @@ class BiomartServer(Properties):
         self.add_property('https_proxy', kwargs.get(
             'https_proxy',  os.environ.get('https_proxy',  None)))
         self.add_property('is_alive', kwargs.get('is_alive', False))
-
         self._verbose = kwargs.get('verbose', False)
         self.assert_alive()
 
     def get_verbose(self):
+        """Return if verbose is set or not"""
         return self._verbose
 
     def set_verbose(self, value):
+        """"""
         if not isinstance(value, bool):
             raise biomart.BiomartException(
                 "verbose must be set to a boolean value")
         setattr(self, '_verbose', value)
+
         # propagate verbose state to databases and datasets objects
         if hasattr(self, '_databases'):
             for database in self._databases.values():
@@ -43,14 +49,19 @@ class BiomartServer(Properties):
     verbose = property(get_verbose, set_verbose)
 
     def assert_alive(self):
+        """Set the connection to the server alive"""
         if not self.is_alive:
             self.GET()
             self.is_alive = True
             if self.verbose:
                 print "[BiomartServer:'%s'] is alive." % self.url
+        else:
+            print "[BiomartServer:'%s'] is already alive." % self.url
 
     @property
     def databases(self):
+        """Return a dictionary with the available databases and a description
+         of them."""
         if not hasattr(self, '_databases'):
             self._databases = {}
             self.fetch_databases()
@@ -58,12 +69,15 @@ class BiomartServer(Properties):
 
     @property
     def datasets(self):
+        """Prints the available datasets as a dictionary:
+        The name of the database as a key and a simple description as a value"""
         if not hasattr(self, '_datasets'):
             self._datasets = {}
             self.fetch_datasets()
         return self._datasets
 
     def fetch_databases(self):
+        """Fetch the name and description of the databases."""
         if self.verbose:
             print "[BiomartServer:'%s'] Fetching databases" % self.url
 
@@ -85,8 +99,12 @@ class BiomartServer(Properties):
                 verbose=self.verbose,
                 is_alive=self.is_alive
             )
+        if self.verbose:
+            print "[BiomartServer:'%s'] Successfully fetch databases" % self.url
 
     def fetch_datasets(self):
+        """Fetch datasets of the databases"""
+        # TODO: Add the possibility to obtain the datasets of a single database
         if self.verbose:
             print "[BiomartServer:'%s'] Fetching datasets" % self.url
 
@@ -96,13 +114,24 @@ class BiomartServer(Properties):
         for database in self.databases.values():
             self._datasets.update(database.datasets)
 
+        if self.verbose:
+            print "[BiomartServer:'%s'] Successfully fetch datasets" % self.url
+
     def show_databases(self):
+        """Show a dictionary with the name of the database and a description"""
         pprint.pprint(self.databases)
 
     def show_datasets(self):
+        """Prints a table with information about each dataset. The information is:
+        Type of data, ¿name of the dataset?, ¿description of the dataset?, ¿?, 
+        ¿version?, columns?, rows?, permision, datestamp
+        Example:
+        TableSet    pinfestans_eg_snp    Phytophthora infestans variations 
+        (ASM14294v1)    1    ASM14294v1    200    50000    default    2014-12-18 15:44:39"""
         pprint.pprint(self.datasets)
 
-    def GET(self, **params):
+    def get(self, **params):
+        """Test if the server and the databases return the right status code"""
         proxies = {
             'http': self.http_proxy,
             'https': self.https_proxy

--- a/biomart/server.py
+++ b/biomart/server.py
@@ -1,32 +1,37 @@
 import os
 import pprint
-from xml.etree.ElementTree import fromstring
-
 import requests
+from xml.etree.ElementTree import fromstring
 
 import biomart
 from lib import Properties, PUBLIC_BIOMART_URL
 
+
 class BiomartServer(Properties):
-    def __init__(self, url = PUBLIC_BIOMART_URL, *args, **kwargs):
+
+    def __init__(self, url=PUBLIC_BIOMART_URL, *args, **kwargs):
         if not 'martservice' in url:
             url += '/martservice'
         if not 'http://' in url:
             url = 'http://' + url
 
         self.add_property('url', url)
-        self.add_property('http_proxy', kwargs.get('http_proxy',  os.environ.get('http_proxy',  None)))
-        self.add_property('https_proxy', kwargs.get('https_proxy',  os.environ.get('https_proxy',  None)))
+        self.add_property(
+            'http_proxy', kwargs.get('http_proxy',  os.environ.get('http_proxy',  None)))
+        self.add_property('https_proxy', kwargs.get(
+            'https_proxy',  os.environ.get('https_proxy',  None)))
         self.add_property('is_alive', kwargs.get('is_alive', False))
-        
+
         self._verbose = kwargs.get('verbose', False)
         self.assert_alive()
 
     def get_verbose(self):
         return self._verbose
+
     def set_verbose(self, value):
         if not isinstance(value, bool):
-            raise biomart.BiomartException("verbose must be set to a boolean value")
+            raise biomart.BiomartException(
+                "verbose must be set to a boolean value")
         setattr(self, '_verbose', value)
         # propagate verbose state to databases and datasets objects
         if hasattr(self, '_databases'):
@@ -36,74 +41,77 @@ class BiomartServer(Properties):
             for dataset in self._datasets.values():
                 dataset.verbose = True
     verbose = property(get_verbose, set_verbose)
-    
+
     def assert_alive(self):
         if not self.is_alive:
             self.GET()
             self.is_alive = True
-            if self.verbose: print "[BiomartServer:'%s'] is alive." % self.url
-    
+            if self.verbose:
+                print "[BiomartServer:'%s'] is alive." % self.url
+
     @property
     def databases(self):
         if not hasattr(self, '_databases'):
             self._databases = {}
             self.fetch_databases()
         return self._databases
-    
+
     @property
     def datasets(self):
         if not hasattr(self, '_datasets'):
             self._datasets = {}
             self.fetch_datasets()
         return self._datasets
-    
+
     def fetch_databases(self):
-        if self.verbose: print "[BiomartServer:'%s'] Fetching databases" % self.url
+        if self.verbose:
+            print "[BiomartServer:'%s'] Fetching databases" % self.url
 
         if not hasattr(self, '_databases'):
             self._databases = {}
 
-        r = self.GET( type = 'registry' )
+        r = self.GET(type='registry')
         xml = fromstring(r.text)
         for child in xml.findall('MartURLLocation'):
             name = child.attrib['name']
 
-            self._databases[ name ] = biomart.BiomartDatabase(
-                url         = self.url,
-                http_proxy  = self.http_proxy,
-                https_proxy = self.https_proxy,
-                name        = name,
-                displayName = child.attrib['displayName'],
-                visible     = child.attrib['visible'],
-                verbose     = self.verbose,
-                is_alive    = self.is_alive
+            self._databases[name] = biomart.BiomartDatabase(
+                url=self.url,
+                http_proxy=self.http_proxy,
+                https_proxy=self.https_proxy,
+                name=name,
+                displayName=child.attrib['displayName'],
+                visible=child.attrib['visible'],
+                verbose=self.verbose,
+                is_alive=self.is_alive
             )
-    
+
     def fetch_datasets(self):
-        if self.verbose: print "[BiomartServer:'%s'] Fetching datasets" % self.url
+        if self.verbose:
+            print "[BiomartServer:'%s'] Fetching datasets" % self.url
 
         if not hasattr(self, '_datasets'):
             self._datasets = {}
-        
+
         for database in self.databases.values():
-            self._datasets.update( database.datasets )
-    
+            self._datasets.update(database.datasets)
+
     def show_databases(self):
-        pprint.pprint( self.databases )
-    
+        pprint.pprint(self.databases)
+
     def show_datasets(self):
-        pprint.pprint( self.datasets )
-    
+        pprint.pprint(self.datasets)
+
     def GET(self, **params):
         proxies = {
             'http': self.http_proxy,
             'https': self.https_proxy
         }
         if params:
-            r = requests.get( self.url, params = params, proxies = proxies, stream = True )
+            r = requests.get(
+                self.url, params=params, proxies=proxies, stream=True)
         else:
-            r = requests.get( self.url, proxies = proxies )
+            r = requests.get(self.url, proxies=proxies)
         r.raise_for_status()
 
         return r
-

--- a/biomart/test/__init__.py
+++ b/biomart/test/__init__.py
@@ -1,9 +1,9 @@
 import test_server
 import test_database
 import test_dataset
+import unittest
 
 def suite():
-    import unittest
     import doctest
     suite = unittest.TestSuite()
     suite.addTests(test_server.suite())

--- a/biomart/test/__init__.py
+++ b/biomart/test/__init__.py
@@ -1,6 +1,8 @@
 import test_server
 import test_database
 import test_dataset
+import test_filter
+import test_attribute
 import unittest
 
 def suite():
@@ -9,6 +11,8 @@ def suite():
     suite.addTests(test_server.suite())
     suite.addTests(test_database.suite())
     suite.addTests(test_dataset.suite())
+    suite.addTest(test_filter.suite())
+    suite.addTest(test_attribute.suite())
     return suite
 
 if __name__ == '__main__':

--- a/biomart/test/test_attribute.py
+++ b/biomart/test/test_attribute.py
@@ -1,0 +1,29 @@
+import unittest
+
+import biomart
+from biomart.lib import PUBLIC_BIOMART_URL
+
+class BiomartAttributeTestCase(unittest.TestCase):
+#     def setUp(self):
+#         self.database = biomart.BiomartDatabase( url = PUBLIC_BIOMART_URL, name = 'unimart' )
+#     
+#     def testCanConnectToDatabase(self):
+#         self.assertTrue( self.database.is_alive )
+#     
+#     def testCanFetchDatasets(self):
+#         self.database.fetch_datasets()
+#         self.assertTrue( len(self.database.datasets.keys()) > 0 )
+#     
+#     def testCanSelectDataset(self):
+#         uniprot = self.database.datasets['uniprot']
+#         self.assertTrue( uniprot.is_alive )
+    pass
+
+def suite():
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTest(loader.loadTestsFromTestCase(BiomartAttributeTestCase))
+    return suite
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/biomart/test/test_database.py
+++ b/biomart/test/test_database.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 
 import biomart

--- a/biomart/test/test_dataset.py
+++ b/biomart/test/test_dataset.py
@@ -1,6 +1,5 @@
 import unittest
 import biomart
-import os
 import requests
 from biomart.lib import PUBLIC_BIOMART_URL
 

--- a/biomart/test/test_filter.py
+++ b/biomart/test/test_filter.py
@@ -1,0 +1,29 @@
+import unittest
+
+import biomart
+from biomart.lib import PUBLIC_BIOMART_URL
+
+class BiomartFilterTestCase(unittest.TestCase):
+#     def setUp(self):
+#         self.database = biomart.BiomartDatabase( url = PUBLIC_BIOMART_URL, name = 'unimart' )
+#     
+#     def testCanConnectToDatabase(self):
+#         self.assertTrue( self.database.is_alive )
+#     
+#     def testCanFetchDatasets(self):
+#         self.database.fetch_datasets()
+#         self.assertTrue( len(self.database.datasets.keys()) > 0 )
+#     
+#     def testCanSelectDataset(self):
+#         uniprot = self.database.datasets['uniprot']
+#         self.assertTrue( uniprot.is_alive )
+    pass
+
+def suite():
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTest(loader.loadTestsFromTestCase(BiomartFilterTestCase))
+    return suite
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/biomart/test/test_server.py
+++ b/biomart/test/test_server.py
@@ -1,6 +1,5 @@
 import unittest
 import biomart
-import os
 
 class BiomartServerTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
I made changes on my fork that might be useful/ of interest.
 * Added the lib.py document from the source of the package, that in this repository isn't.
 * Added the possibility to add a parameter to fetch_databases, and fetch_datasets to select a previous known database name, to avoid connecting to all the databases before finding the right one. 
 * Unused imports were removed, dumb files which should test filters and attributes.
 * Added docstrings to almost all methods and objects.

I changed the attributes and the filters object attributes to include all the information and to a list with the objects instead of a dictionary. 