### PR TITLE
Updated the BiomartServer

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -28,7 +28,7 @@ Import Biomart module
 Connect to a Biomart Server
 ::
   
-  server = BiomartServer( "http://www.biomart.org/biomart" )
+  server = BiomartServer( "http://www.ensembl.org/biomart" )
   
   # if you are behind a proxy
   import os


### PR DESCRIPTION
I corrected the URL for biomart server.

It seems like that Biomart server is no longer hosted at http://www.biomart.org/biomart.
Instead, I found that ENSEMBL server (http://www.ensembl.org/biomart) works well with this package!

(cf. https://gist.github.com/yk-tanigawa/dcd432f8aa315640f52b)