### PR TITLE
Implemented handling of multiple attributes' pages

### DIFF
--- a/biomart/__init__.py
+++ b/biomart/__init__.py
@@ -3,6 +3,7 @@ from .database import BiomartDatabase
 from .dataset import BiomartDataset
 from .filter import BiomartFilter
 from .attribute import BiomartAttribute
+from .attribute_page import BiomartAttributePage
 
 class BiomartException(Exception):
     pass

--- a/biomart/attribute.py
+++ b/biomart/attribute.py
@@ -1,9 +1,8 @@
 class BiomartAttribute(object):
-    def __init__(self, name, display_name, attribute_page, is_default = False):
+    def __init__(self, name, display_name, is_default = False):
         self.name = name
         self.display_name = display_name
-        self.attribute_page = attribute_page
         self.is_default = is_default
 
     def __repr__(self):
-        return "'%s' (page: %s, default: %s)" % (self.display_name, self.attribute_page, self.is_default)
+        return "'%s' (default: %s)" % (self.display_name, self.is_default)

--- a/biomart/attribute_page.py
+++ b/biomart/attribute_page.py
@@ -10,4 +10,4 @@ class BiomartAttributePage(object):
         self.attributes[attribute.name] = attribute
 
     def __repr__(self):
-        return "'%s' (# of attributes: %d, defaults: %s)" % (self.display_name, len(self.attributes), repr(self.default_attributes))
+        return "'%s': (attributes: %s, defaults: %s)" % (self.display_name, self.attributes, repr(self.default_attributes))

--- a/biomart/attribute_page.py
+++ b/biomart/attribute_page.py
@@ -1,0 +1,13 @@
+class BiomartAttributePage(object):
+    def __init__(self, name, display_name=None, attributes=None, default_attributes=None):
+        self.name = name
+        self.display_name = display_name or name
+        self.attributes = attributes if attributes else {}
+        self.default_attributes = default_attributes if default_attributes else []
+
+    def add(self, attribute):
+        attribute.is_default = attribute.name in self.default_attributes
+        self.attributes[attribute.name] = attribute
+
+    def __repr__(self):
+        return "'%s' (# of attributes: %d, defaults: %s)" % (self.display_name, len(self.attributes), repr(self.default_attributes))

--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -83,6 +83,24 @@ class BiomartDataset(object):
                     filter_type = line[5],
                 )
 
+
+        # retrieve additional filters from the dataset configuration page
+        r = self.server.get_request(type="configuration", dataset=self.name)
+        xml = fromstring(r.text)
+
+        for attribute_page in xml.findall('./AttributePage'):
+
+            for attribute in attribute_page.findall('./*/*/AttributeDescription[@pointerFilter]'):
+                name = attribute.get('pointerFilter')
+
+                if not name in self._filters:
+                    self._filters[name] = biomart.BiomartFilter(
+                        name = name,
+                        display_name = attribute.get('displayName') or name,
+                        accepted_values = '',
+                        filter_type = '',
+                    )
+
     def fetch_attributes(self):
         if self.verbose:
             print("[BiomartDataset:'%s'] Fetching attributes" % self.name)

--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -40,7 +40,10 @@ class BiomartDataset(object):
         """
         if not self._attribute_pages:
             self.fetch_attributes()
-        return {x:y for x, y in [page.attributes for page in self._attribute_pages.values()]}
+        result = {}
+        for page in self._attribute_pages.values():
+            result.update(page.attributes)
+        return result
 
 
     @property
@@ -66,6 +69,9 @@ class BiomartDataset(object):
 
     def show_attributes(self):
         pprint.pprint(self.attributes)
+
+    def show_attributes_by_page(self):
+        pprint.pprint(self.attribute_pages)
 
     def fetch_filters(self):
         if self.verbose:

--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -110,7 +110,8 @@ class BiomartDataset(object):
             dataset_filter = self.filters.get(filter_name, None)
 
             if not dataset_filter:
-                self.show_filters()
+                if self.verbose:
+                    self.show_filters()
                 raise biomart.BiomartException("The filter '%s' does not exist." % filter_name)
 
             if len(dataset_filter.accepted_values) > 0 and filter_value not in dataset_filter.accepted_values:
@@ -130,12 +131,14 @@ class BiomartDataset(object):
 
             for attribute_name in attributes:
                 if attribute_name not in self.attributes.keys():
-                    self.show_attributes()
+                    if self.verbose:
+                        self.show_attributes()
                     raise biomart.BiomartException("The attribute '%s' does not exist." % attribute_name)
 
             # selected attributes must belong to the same attribute page.
             if len(set([self.attributes[a].attribute_page for a in attributes])) > 1:
-                self.show_attributes()
+                if self.verbose:
+                        self.show_attributes()
                 raise biomart.BiomartException("You must use attributes that belong to the same attribute page.")
 
         # filters and attributes looks ok, start building the XML query


### PR DESCRIPTION
I've reworked some parts of the dataset code and created a new class for attribute pages. This allows use of multiple pages of attributes, without errors. I had to rework some parts of the code, but the API should remain mainly unchanged. This fixes: #12.

Moreover, I added a workaround for an issue with some of queries made to Ensembl, where there are essential additional filters, defined not in 'filters' as if everyone would expect, but in AttributesPage schema. This fixes: #13.

Third change is decrease in default level of verbosity when some bugs occur. In my opinion showing few screens long lists of correct attributes does not makes debugging easier, but feel free to revert this change.

Don't hesitate to ask for small corrections or to merge the pull selectively. Please, inform me if / when the new version will be available :)