### PR TITLE
Allow use of multiple-choice filters

### DIFF
--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -145,7 +145,7 @@ class BiomartDataset(object):
                 attribute = biomart.BiomartAttribute(name=name, display_name=line[1])
                 self._attribute_pages[page].add(attribute)
 
-    def search(self, params = {}, header = 0, count = False):
+    def search(self, params={}, header=0, count=False, formatter='TSV'):
         if not isinstance(params, dict):
             raise biomart.BiomartException("'params' argument must be a dict")
 
@@ -226,7 +226,7 @@ class BiomartDataset(object):
         root = Element('Query')
         root.attrib.update({
             'virtualSchemaName': 'default',  # TODO: use database virtualSchemaName instead (if any error)
-            'formatter': 'TSV',
+            'formatter': formatter,
             'header': str(header),
             'uniqueRows': '1',
             'datasetConfigVersion': '0.6',

--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -166,10 +166,19 @@ class BiomartDataset(object):
                     self.show_filters()
                 raise biomart.BiomartException("The filter '%s' does not exist." % filter_name)
 
-            if len(dataset_filter.accepted_values) > 0 and filter_value not in dataset_filter.accepted_values:
-                error_msg = "The value '%s' for filter '%s' cannot be used." % (filter_value, filter_name)
-                error_msg += " Use one of: [%s]" % ", ".join(map(str, dataset_filter.accepted_values))
-                raise biomart.BiomartException(error_msg)
+            accepted_values = dataset_filter.accepted_values
+            if len(accepted_values) > 0:
+                incorrect_value = None
+
+                if (isinstance(filter_value, list) or isinstance(filter_value, tuple)) and dataset_filter.filter_type == 'list':
+                    incorrect_value = filter(lambda v: v not in accepted_values, filter_value)
+                elif filter_value not in accepted_values:
+                    incorrect_value = filter_value
+
+                if incorrect_value:
+                    error_msg = "the value(s) '%s' for filter '%s' cannot be used." % (incorrect_value, filter_name)
+                    error_msg += " Use values from: [%s]" % ", ".join(map(str, accepted_values))
+                    raise biomart.BiomartException(error_msg)
 
         # check attributes unless we're only counting
         if not count:


### PR DESCRIPTION
Some biomarts use filters of _list_ type. That means we can (for example) filter out all items originating from sources not present in the list. The current version of the package fails to recognize those filters correctly if they provide an 'accepted values' field. I have improved the code in `dataset.py` file, so it no longer raises unnecessary exceptions.  

The test code:

```
from biomart import BiomartDataset
som_snp = BiomartDataset('www.ensembl.org/biomart', name='hsapiens_snp_som')
query_dict = {
        'attributes': [u'refsnp_id'],
        'filters': {u'so_parent_name': ['exon_variant', 'coding_sequence_variant']}
             }

response = som_snp.search(query_dict)
for line in response.iter_lines():
        line = line.decode('utf-8')
        print(line.split("\t"))
```
