### PR TITLE
Submit query through POST, specify support only for Python3.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,3 +10,4 @@ v0.7.1, 09/09/2015 -- fixed relative imports for python3
 v0.8.0, 01/10/2015 -- New design of classes, new way of fetching attributes and filters for datasets. Still need to figure out the actual need for virtualSchemaName, for now 'default' is used for all datasets.
 v0.9.0, 07/04/2016 -- The module is now aware of AttributePages and will check whether selected attributes all belong to the same page. thanks to krassowski for his work.
 v0.9.2, 22/01/2017 -- Now considering virtualSchemaName value when searching (was always using 'default')
+v1.0.0, 05/07/2017 -- Implemented query with XML file through POST request to overcome the limit of longest GET URL set on the Apache server of the biomart website.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ What it won't do:
 Usage
 -----
 
-<pre>
+```python
 # Import Biomart module
 from biomart import BiomartServer
 
@@ -65,41 +65,33 @@ for line in response.iter_lines():
 response = ds.count()
 print(response)
 
-## OLD EXAMPLE BELOW
-
 # run a search with custom filters and default attributes.
-response = uniprot.search({
-'filters': {
-    'accession': 'Q9FMA1'
-}
-}, header = 1 )
+response = ds.search({
+    'filters':{
+        'ensembl_gene_id':'ENSG00000132646'
+    }
+}, header = 1)
 
-response = uniprot.search({
-'filters': {
-    'accession': ['Q9FMA1', 'Q8LFJ9']  # ID-list specified accessions
-}
-}, header = 1 )
+response = ds.search({
+    'filters':{
+        'ensembl_gene_id':['ENSG00000132646', 'ENSG00000141510']
+    }
+}, header = 1)
 
 # run a search with custom filters and attributes (no header)
-response = uniprot.search({
-'filters': {
-    'accession': ['Q9FMA1', 'Q8LFJ9']
-},
-'attributes': [
-    'accession', 'protein_name'
-]
-})
-</pre>
+response = ds.search({
+    'filters':{
+        'ensembl_gene_id':['ENSG00000132646', 'ENSG00000141510']
+    },
+    'attributes':[
+        'ensembl_gene_id',              # Gene ID
+        'chromosome_name',              # Chromosome
+        'start_position',               # Start
+        'end_position',                 # End
+        'strand',                       # Strand
+        'transcript_count',             # Number of transcripts
+        'percentage_gene_gc_content'    # GC content percentage
+    ]
+}, header = 1)
+```
 
-Shortcut function: connect directly to a biomart dataset
-*This is short in code but it might be long in time since the module needs to fetch all server's databases to find your dataset.*
-<pre>
-from biomart import BiomartDataset
-
-interpro = BiomartDataset( "http://www.biomart.org/biomart", name = 'entry' )
-
-response = interpro.search({
-'filters': { 'entry_id': 'IPR027603' },
-'attributes': [ 'entry_name', 'abstract' ]
-})
-</pre>

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Usage
 -----
 
 ```python
+
 # Import Biomart module
 from biomart import BiomartServer
 
@@ -50,10 +51,10 @@ ds.show_attributes()
 # Run a search with the default attributes
 # It is equivalent to hitting "Results" on the web interface.
 # This will return a lot of data.
-response = ds.search()
+#response = ds.search()
 
 # If you need the columns header
-response = ds.search( header = 1 )
+#response = ds.search( header = 1 )
 
 # Response format is TSV
 for line in response.iter_lines():
@@ -93,5 +94,23 @@ response = ds.search({
         'percentage_gene_gc_content'    # GC content percentage
     ]
 }, header = 1)
+
+# To convert the response variable to a more readable format
+# let's take advantage of the numpy and pandas libraries
+import numpy as np
+import pandas as pd
+
+# Convert to easily accessible numpy array
+response = np.array([row.split('\t')
+    for row in response.text.strip().split('\n')])
+
+# Convert to easy-to-read pandas dataframe
+# With header line
+response = pd.DataFrame(response[1:,:], columns = response[0])
+# Without header line
+response = pd.DataFrame(response)
+
+print(response)
+
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-=============
+
 Biomart 0.9.2
 =============
 
 Python API that consumes the biomart webservice.
+
+**!!!NOTE: this package is compatible with Python3 and higher versions.**
 
 What it will do:
 ----------------
@@ -20,53 +22,50 @@ What it won't do:
 Usage
 -----
 
-Import Biomart module
 <pre>
+# Import Biomart module
 from biomart import BiomartServer
-</pre>
-Connect to a Biomart Server
-<pre>
-server = BiomartServer( "http://www.biomart.org/biomart" )
-  
-# if you are behind a proxy
-import os
-server.http_proxy = os.environ.get('http_proxy', 'http://my_http_proxy.org')
 
-# set verbose to True to get some messages
+# Connect to biomart server
+server = BiomartServer( "http://www.ensembl.org/biomart" )
 server.verbose = True
-</pre>
 
-Interact with the biomart server
-<pre>
-# show server databases
-server.show_databases() # uses pprint behind the scenes
+# Check available databases
+server.show_databases()
 
-# show server datasets
-server.show_datasets() # uses pprint behind the scenes
+# Select a database
+db = server.databases['ENSEMBL_MART_ENSEMBL']
 
-# use the 'uniprot' dataset
-uniprot = server.datasets['uniprot']
+# Check available datasets (species)
+db.show_datasets()
 
-# show all available filters and attributes of the 'uniprot' dataset
-uniprot.show_filters()  # uses pprint
-uniprot.show_attributes()  # uses pprint
-</pre>
+# Select a dataset
+ds = db.datasets['hsapiens_gene_ensembl']
 
-Run a search
-<pre>
-# run a search with the default attributes - equivalent to hitting "Results" on the web interface.
-# this will return a lot of data.
-response = uniprot.search()
-response = uniprot.search( header = 1 ) # if you need the columns header
+# Show all available filters and attributes
+# for the selected dataset
+ds.show_filters()
+ds.show_attributes()
 
-# response format is TSV
+# Run a search with the default attributes
+# It is equivalent to hitting "Results" on the web interface.
+# This will return a lot of data.
+response = ds.search()
+
+# If you need the columns header
+response = ds.search( header = 1 )
+
+# Response format is TSV
 for line in response.iter_lines():
-line = line.decode('utf-8')
-print(line.split("\t"))
+    line = line.decode('utf-8')
+    print(line.split("\t"))
 
-# run a count - equivalent to hitting "Count" on the web interface
-response = uniprot.count()
-print(response.text)
+# Run a count
+# It is equivalent to hitting "Count" on the web interface
+response = ds.count()
+print(response)
+
+## OLD EXAMPLE BELOW
 
 # run a search with custom filters and default attributes.
 response = uniprot.search({

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-Biomart 0.9.2
+Biomart 1.0.0
 =============
 
 Python API that consumes the biomart webservice.

--- a/README.txt
+++ b/README.txt
@@ -4,6 +4,8 @@ Biomart 0.9.2
 
 Python API that consumes the biomart webservice.
 
+**!!!NOTE: this package is compatible with Python3 and higher versions.**
+
 What it will do:
 ----------------
 
@@ -20,56 +22,50 @@ What it won't do:
 Usage
 -----
 
-Import Biomart module
 ::
-  
+  # Import Biomart module
   from biomart import BiomartServer
 
-Connect to a Biomart Server
-::
-  
-  server = BiomartServer( "http://www.biomart.org/biomart" )
-  
-  # if you are behind a proxy
-  import os
-  server.http_proxy = os.environ.get('http_proxy', 'http://my_http_proxy.org')
-
-  # set verbose to True to get some messages
+  # Connect to biomart server
+  server = BiomartServer( "http://www.ensembl.org/biomart" )
   server.verbose = True
 
-Interact with the biomart server
-::
-  
-  # show server databases
-  server.show_databases() # uses pprint behind the scenes
-  
-  # show server datasets
-  server.show_datasets() # uses pprint behind the scenes
-  
-  # use the 'uniprot' dataset
-  uniprot = server.datasets['uniprot']
+  # Check available databases
+  server.show_databases()
 
-  # show all available filters and attributes of the 'uniprot' dataset
-  uniprot.show_filters()  # uses pprint
-  uniprot.show_attributes()  # uses pprint
+  # Select a database
+  db = server.databases['ENSEMBL_MART_ENSEMBL']
 
+  # Check available datasets (species)
+  db.show_datasets()
 
-Run a search
-::
+  # Select a dataset
+  ds = db.datasets['hsapiens_gene_ensembl']
 
-  # run a search with the default attributes - equivalent to hitting "Results" on the web interface.
-  # this will return a lot of data.
-  response = uniprot.search()
-  response = uniprot.search( header = 1 ) # if you need the columns header
-  
-  # response format is TSV
+  # Show all available filters and attributes
+  # for the selected dataset
+  ds.show_filters()
+  ds.show_attributes()
+
+  # Run a search with the default attributes
+  # It is equivalent to hitting "Results" on the web interface.
+  # This will return a lot of data.
+  response = ds.search()
+
+  # If you need the columns header
+  response = ds.search( header = 1 )
+
+  # Response format is TSV
   for line in response.iter_lines():
     line = line.decode('utf-8')
     print(line.split("\t"))
-  
-  # run a count - equivalent to hitting "Count" on the web interface
-  response = uniprot.count()
-  print(response.text)
+
+  # Run a count
+  # It is equivalent to hitting "Count" on the web interface
+  response = ds.count()
+  print(response)
+
+  ## OLD EXAMPLE BELOW
 
   # run a search with custom filters and default attributes.
   response = uniprot.search({

--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,5 @@
 =============
-Biomart 0.9.2
+Biomart 1.0.0
 =============
 
 Python API that consumes the biomart webservice.

--- a/README.txt
+++ b/README.txt
@@ -50,48 +50,63 @@ Usage
 	# Run a search with the default attributes
 	# It is equivalent to hitting "Results" on the web interface.
 	# This will return a lot of data.
-	response = ds.search()
+	#response = ds.search()
 
 	# If you need the columns header
-	response = ds.search( header = 1 )
+	#response = ds.search( header = 1 )
 
 	# Response format is TSV
 	for line in response.iter_lines():
-		line = line.decode('utf-8')
-		print(line.split("\t"))
+	    line = line.decode('utf-8')
+	    print(line.split("\t"))
 
 	# Run a count
 	# It is equivalent to hitting "Count" on the web interface
 	response = ds.count()
 	print(response)
 
-	## OLD EXAMPLE BELOW
-
 	# run a search with custom filters and default attributes.
 	response = ds.search({
-		'filters':{
-			'ensembl_gene_id':'ENSG00000132646'
-		}
+	    'filters':{
+	        'ensembl_gene_id':'ENSG00000132646'
+	    }
 	}, header = 1)
 
 	response = ds.search({
-		'filters':{
-			'ensembl_gene_id':['ENSG00000132646', 'ENSG00000141510']
-		}
+	    'filters':{
+	        'ensembl_gene_id':['ENSG00000132646', 'ENSG00000141510']
+	    }
 	}, header = 1)
 
 	# run a search with custom filters and attributes (no header)
 	response = ds.search({
-		'filters':{
-			'ensembl_gene_id':['ENSG00000132646', 'ENSG00000141510']
-		},
-		'attributes':[
-			'ensembl_gene_id',				# Gene ID
-			'chromosome_name',				# Chromosome
-			'start_position',				# Start
-			'end_position',					# End
-			'strand',						# Strand
-			'transcript_count',				# Number of transcripts
-			'percentage_gene_gc_content'	# GC content percentage
-		]
+	    'filters':{
+	        'ensembl_gene_id':['ENSG00000132646', 'ENSG00000141510']
+	    },
+	    'attributes':[
+	        'ensembl_gene_id',              # Gene ID
+	        'chromosome_name',              # Chromosome
+	        'start_position',               # Start
+	        'end_position',                 # End
+	        'strand',                       # Strand
+	        'transcript_count',             # Number of transcripts
+	        'percentage_gene_gc_content'    # GC content percentage
+	    ]
 	}, header = 1)
+
+	# To convert the response variable to a more readable format
+	# let's take advantage of the numpy and pandas libraries
+	import numpy as np
+	import pandas as pd
+
+	# Convert to easily accessible numpy array
+	response = np.array([row.split('\t')
+	    for row in response.text.strip().split('\n')])
+
+	# Convert to easy-to-read pandas dataframe
+	# With header line
+	response = pd.DataFrame(response[1:,:], columns = response[0])
+	# Without header line
+	response = pd.DataFrame(response)
+
+	print(response)

--- a/README.txt
+++ b/README.txt
@@ -23,83 +23,75 @@ Usage
 -----
 
 ::
-  # Import Biomart module
-  from biomart import BiomartServer
+	# Import Biomart module
+	from biomart import BiomartServer
 
-  # Connect to biomart server
-  server = BiomartServer( "http://www.ensembl.org/biomart" )
-  server.verbose = True
+	# Connect to biomart server
+	server = BiomartServer( "http://www.ensembl.org/biomart" )
+	server.verbose = True
 
-  # Check available databases
-  server.show_databases()
+	# Check available databases
+	server.show_databases()
 
-  # Select a database
-  db = server.databases['ENSEMBL_MART_ENSEMBL']
+	# Select a database
+	db = server.databases['ENSEMBL_MART_ENSEMBL']
 
-  # Check available datasets (species)
-  db.show_datasets()
+	# Check available datasets (species)
+	db.show_datasets()
 
-  # Select a dataset
-  ds = db.datasets['hsapiens_gene_ensembl']
+	# Select a dataset
+	ds = db.datasets['hsapiens_gene_ensembl']
 
-  # Show all available filters and attributes
-  # for the selected dataset
-  ds.show_filters()
-  ds.show_attributes()
+	# Show all available filters and attributes
+	# for the selected dataset
+	ds.show_filters()
+	ds.show_attributes()
 
-  # Run a search with the default attributes
-  # It is equivalent to hitting "Results" on the web interface.
-  # This will return a lot of data.
-  response = ds.search()
+	# Run a search with the default attributes
+	# It is equivalent to hitting "Results" on the web interface.
+	# This will return a lot of data.
+	response = ds.search()
 
-  # If you need the columns header
-  response = ds.search( header = 1 )
+	# If you need the columns header
+	response = ds.search( header = 1 )
 
-  # Response format is TSV
-  for line in response.iter_lines():
-    line = line.decode('utf-8')
-    print(line.split("\t"))
+	# Response format is TSV
+	for line in response.iter_lines():
+		line = line.decode('utf-8')
+		print(line.split("\t"))
 
-  # Run a count
-  # It is equivalent to hitting "Count" on the web interface
-  response = ds.count()
-  print(response)
+	# Run a count
+	# It is equivalent to hitting "Count" on the web interface
+	response = ds.count()
+	print(response)
 
-  ## OLD EXAMPLE BELOW
+	## OLD EXAMPLE BELOW
 
-  # run a search with custom filters and default attributes.
-  response = uniprot.search({
-    'filters': {
-        'accession': 'Q9FMA1'
-    }
-  }, header = 1 )
-  
-  response = uniprot.search({
-    'filters': {
-        'accession': ['Q9FMA1', 'Q8LFJ9']  # ID-list specified accessions
-    }
-  }, header = 1 )
-  
-  # run a search with custom filters and attributes (no header)
-  response = uniprot.search({
-    'filters': {
-        'accession': ['Q9FMA1', 'Q8LFJ9']
-    },
-    'attributes': [
-        'accession', 'protein_name'
-    ]
-  })
+	# run a search with custom filters and default attributes.
+	response = ds.search({
+		'filters':{
+			'ensembl_gene_id':'ENSG00000132646'
+		}
+	}, header = 1)
 
+	response = ds.search({
+		'filters':{
+			'ensembl_gene_id':['ENSG00000132646', 'ENSG00000141510']
+		}
+	}, header = 1)
 
-Shortcut function: connect directly to a biomart dataset
-*This is short in code but it might be long in time since the module needs to fetch all server's databases to find your dataset.*
-::
-  
-  from biomart import BiomartDataset
-  
-  interpro = BiomartDataset( "http://www.biomart.org/biomart", name = 'entry' )
-  
-  response = interpro.search({
-    'filters': { 'entry_id': 'IPR027603' },
-    'attributes': [ 'entry_name', 'abstract' ]
-  })
+	# run a search with custom filters and attributes (no header)
+	response = ds.search({
+		'filters':{
+			'ensembl_gene_id':['ENSG00000132646', 'ENSG00000141510']
+		},
+		'attributes':[
+			'ensembl_gene_id',				# Gene ID
+			'chromosome_name',				# Chromosome
+			'start_position',				# Start
+			'end_position',					# End
+			'strand',						# Strand
+			'transcript_count',				# Number of transcripts
+			'percentage_gene_gc_content'	# GC content percentage
+		]
+	}, header = 1)

--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -273,7 +273,7 @@ class BiomartDataset(object):
         if self.verbose:
             print("[BiomartDataset] search query:\n%s" % tostring(root))
 
-        return self.server.get_request(query = tostring(root))
+        return self.server.post_query(query = tostring(root))
 
     def count(self, params = {}):
         r = self.search(params, count = True)

--- a/biomart/lib/__init__.py
+++ b/biomart/lib/__init__.py
@@ -1,2 +1,2 @@
-PUBLIC_BIOMART_URL="http://www.biomart.org/biomart"
-VERSION ="0.8.0"
+PUBLIC_BIOMART_URL="http://www.ensembl.org/biomart"
+VERSION ="1.0.0"

--- a/biomart/server.py
+++ b/biomart/server.py
@@ -104,3 +104,16 @@ class BiomartServer(object):
         r.raise_for_status()
 
         return r
+
+    def post_query(self, query, **params):
+        proxies = {
+            'http': self.http_proxy,
+            'https': self.https_proxy
+        }
+        if params:
+            r = requests.post(self.url, data = {'query' : query}, params = params, proxies = proxies, stream = True)
+        else:
+            r = requests.post(self.url, data = {'query' : query}, proxies = proxies)
+        r.raise_for_status()
+
+        return r

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='biomart',
-    version='0.9.2',
+    version='1.0.0',
     url='https://github.com/sebriois/biomart',
     author='Sebastien Briois',
     author_email='sebriois@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,14 @@ setup(
     install_requires=["requests>=2.2"],
     test_suite = 'biomart.test.suite',
     classifiers=[
+        'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
-    ],
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+    ]
 )


### PR DESCRIPTION
Propose following changes:
- Use Ensembl biomart as default address
- Specify support only for Python3 in both README and setup.py
- Use POST to submit query, to overcome the limit of longest GET URL set on the addressed Apache server
- POST requests are faster than their GET counterpart
- Updated README with example of how to use numpy and pandas to re-format the response text