### PR TITLE
Simple fix for issue #26

### DIFF
--- a/biomart/dataset.py
+++ b/biomart/dataset.py
@@ -254,7 +254,7 @@ class BiomartDataset(object):
             filter_elem = SubElement(dataset, "Filter")
             filter_elem.set('name', filter_name)
 
-            if 'boolean_list' == dataset_filter.filter_type:
+            if dataset_filter.filter_type in ['boolean', 'boolean_list']:
                 if filter_value is True or filter_value.lower() in ('included', 'only'):
                     filter_elem.set('excluded', '0')
                 elif filter_value is False or filter_value.lower() == 'excluded':


### PR DESCRIPTION
I have encountered the same issue as #26, and after looking into it the problem was that the type of the filter was 'boolean' and not 'boolean_list'. The filter was then handled as not boolean, which caused the issue. Since the correct behaviour is already provided, the fix is just to add 'boolean' to the list of recognised filter types.